### PR TITLE
add .dockerignore file to purify docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+*
+!requirements.txt
+!transformer.py


### PR DESCRIPTION
C’était pas demandé mais c'est quand même une bonne pratique après #8 d’avoir un fichier qui spécifie ce que le contexte Docker contient. 